### PR TITLE
Disable sodium extra fog

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -39,7 +39,7 @@
 	"mixins":
 	[
 		"no_fog.mixins.json"
-	]
+	],
 	"custom":
 	{
 		"sodium-extra:options":

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -40,4 +40,15 @@
 	[
 		"no_fog.mixins.json"
 	]
+	"custom":
+	{
+		"sodium-extra:options":
+		{
+			"mixin.fog": false
+		},
+		"sodium extra:options":
+		{
+			"mixin.fog": false
+		}
+	}
 }


### PR DESCRIPTION
Disables sodium extra fog mixin for newer and older versions of Sodium, improves mod compatibility.